### PR TITLE
Blank NuGet package for Farseer Physics portable plus fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-/*.suo
-/FarseerPhysics.Portable/obj/Debug/*.cache
-/FarseerPhysics.Portable/bin/Debug
-/FarseerPhysics.Portable/obj/Debug/*.pdb
-/FarseerPhysics.Portable/obj/Debug
-/packages/MonoGame-Portable.3.2.1
+*.suo
+[Oo]bj
+[Bb]in
+[Pp]ackages

--- a/FarseerPhysics.Portable.1.0.0.nuspec
+++ b/FarseerPhysics.Portable.1.0.0.nuspec
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>FarseerPhysics.Portable</id>
+        <version>1.0.0</version>
+        <title>FarseerPhysics.Portable</title>
+        <authors>&lt;author&gt;</authors>
+        <owners>&lt;owner&gt;</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>My package description.</description>
+    </metadata>
+    <files>
+        <file src="FarseerPhysics.Portable\bin\Release\FarseerPhysics.Portable.dll" target="lib\portable-net4+sl4+wp8+win8\FarseerPhysics.Portable.dll" />
+    </files>
+</package>

--- a/FarseerPhysics.Portable/FarseerPhysics.Portable.csproj
+++ b/FarseerPhysics.Portable/FarseerPhysics.Portable.csproj
@@ -30,7 +30,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -157,7 +157,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework">
-      <HintPath>..\..\packages\MonoGame-Portable.3.2.1\lib\portable-net4+sl5+wp8+win8\MonoGame.Framework.dll</HintPath>
+      <HintPath>..\packages\MonoGame-Portable.3.2.1\lib\portable-net4+sl5+wp8+win8\MonoGame.Framework.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/FarseerPhysics.Portable/packages.config
+++ b/FarseerPhysics.Portable/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MonoGame-Portable" version="3.2.1" targetFramework="portable-net40+sl50+MonoAndroid10+MonoTouch10" />
+  <package id="MonoGame-Portable" version="3.2.1" targetFramework="portable-net40+sl50" />
 </packages>


### PR DESCRIPTION
Updated .GitIgnore
Added NuSpec for FarseerPortable nuGet package (still needs author/owner/description updating)
Re-Added NuGet packages.config to solution as it was missing (stops NuGet package restore working)

Just edit the NuSpec with a text editor or use the NuGet package explorer GUI (http://docs.nuget.org/docs/creating-packages/using-a-gui-to-build-packages)
And add your own detail information.  Dll already packages for PCL's
